### PR TITLE
[Feat] .github/linters: Add .textlintrc

### DIFF
--- a/.github/workflows/linters/.textlintrc
+++ b/.github/workflows/linters/.textlintrc
@@ -1,0 +1,12 @@
+{
+  "filters": {
+    "comments": true
+  },
+  "rules": {
+    "terminology": {
+      "exclude": [
+        "e[- ]mail(s)?",
+        "HTML"
+      ]
+    }
+  }


### PR DESCRIPTION
Exclude a couple of terms from textlint-rule-terminology
which will cause textlint to fail when checking CODE_OF_CONDUCT.md